### PR TITLE
Fix execution failure in clean env

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -34,6 +34,7 @@ if(process.argv.indexOf("-h") !== -1 || process.argv.indexOf("--help") !== -1){
 }
 
 function emptyDirSync(location){
+  if(!fs.existsSync(location)) return;
   const files = fs.readdirSync(location); 
   for (const file of files) {
     const filePath = path.join(location, file);

--- a/test-repository/install-local.sh
+++ b/test-repository/install-local.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 cd ..
+version=$(node -e 'console.log(require("./package.json").version)')
 npm pack .
 cd test-repository
-npm install ../cytorus-0.2.9.tgz
+npm install ../cytorus-$version.tgz

--- a/test-repository/package.json
+++ b/test-repository/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "cy2": "^1.2.1",
     "cypress": "^8.3.1",
-    "cytorus": "file:../cytorus-0.2.8.tgz",
+    "cytorus": "file:../cytorus-0.2.11.tgz",
     "cytorus-reporter": "^1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
If we run cytorus without .cytorus and cypress/integration/cytorus-cache directories, we will get the following error.

```
$ npx cytorus run  --tags "@foo-bar" --spec cypress/integration/features/hyphenated-tags.feature

   .d8888b.           888                                      
  d88P  Y88b          888                                      
  888    888          888                                      
  888        888  888 888888 .d88b.  888d888 888  888 .d8888b  
  888        888  888 888   d88""88b 888P"   888  888 88K      
  888    888 888  888 888   888  888 888     888  888 "Y8888b. 
  Y88b  d88P Y88b 888 Y88b. Y88..88P 888     Y88b 888      X88 
   "Y8888P"   "Y88888  "Y888 "Y88P"  888      "Y88888  88888P' 
                  888                                          
             Y8b d88P 0.2.11                                         
              "Y88P"                                           
  
node:internal/fs/utils:344
    throw err;
    ^

Error: ENOENT: no such file or directory, scandir 'cypress/integration/cytorus-cache/'
    at Object.readdirSync (node:fs:1390:3)
    at emptyDirSync (/workspaces/cytorus/test-repository/node_modules/cytorus/cli.js:37:20)
    at setupWorkSpace (/workspaces/cytorus/test-repository/node_modules/cytorus/cli.js:54:3)
    at Object.<anonymous> (/workspaces/cytorus/test-repository/node_modules/cytorus/cli.js:31:3)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47 {
  errno: -2,
  syscall: 'scandir',
  code: 'ENOENT',
  path: 'cypress/integration/cytorus-cache/'
}
```

This PR fixes this issue.