### PR TITLE
Fix example position handling

### DIFF
--- a/UTs/PositionFilter.test.js
+++ b/UTs/PositionFilter.test.js
@@ -5,25 +5,26 @@ const PositionFilter = rewire('../src/filters/PositionFilter')
 const contains = PositionFilter.__get__("contains");
 
 describe("Position Filter", () => {
-    describe("contains function", ()=>{
+    describe("contains function", () => {
         it("should return true for positions that matched exactly to the example position", () => {
-            expect(contains([1.2, 3, 5], 1, 2), '[1.2, 3, 5] contains 1.2').to.be.true;
+            expect(contains(["1.2", "3", "5"], 1, 2), '[1.2, 3, 5] contains 1.2').to.be.true;
         });
         it("should return true for all example positions if arr contains only scenario position", () => {
-            expect(contains([1, 3, 5], 1, 2), '[1, 3, 5] contains 1.0').to.be.true;
+            expect(contains(["1", "3", "5"], 1, 2), '[1, 3, 5] contains 1.2').to.be.true;
         });
-        it("should return false for positions unmatched position with example", () => {
-            expect(contains([1.2, 3, 5], 1, 1), '[1.2, 3, 5] contains 1.1').to.be.false;
+        it("should return false for positions that unmatched position with example", () => {
+            expect(contains(["1.2", "3", "5"], 1, 1), '[1.2, 3, 5] contains 1.1').to.be.false;
         });
-        it("should handle example position '0' correctly", () => {
-            expect(contains([1.0], 1, 0), '[1.0] contains 1.0"').to.be.true;
-            expect(contains([1.0], 1, 1), '[1.0] contains 1.1').to.be.false;
+        it("should handle first example (0th position) correctly", () => {
+            expect(contains(["1"], 1, 0), '[1] contains 1.0"').to.be.true;
+            expect(contains(["1.0"], 1, 0), '[1.0] contains 1.0"').to.be.true;
+            expect(contains(["1.0"], 1, 1), '[1.0] contains 1.1').to.be.false;
         });
-        it("should handle example position more than 9 correctly", () => {
-            expect(contains([1.10], 1, 10), '[1.10] contains 1.10').to.be.true;
-            expect(contains([1.10], 1, 1), '[1.10] contains 1.1').to.be.false;
-            expect(contains([1.11], 1, 11), '[1.11] contains 1.11').to.be.true;
-            expect(contains([2.1], 1, 11), '[2.1] contains 1.11').to.be.false;
+        it("should handle example position greater than 9 correctly", () => {
+            expect(contains(["1.10"], 1, 10), '[1.10] contains 1.10').to.be.true;
+            expect(contains(["1.10"], 1, 1), '[1.10] contains 1.1').to.be.false;
+            expect(contains(["1.11"], 1, 11), '[1.11] contains 1.11').to.be.true;
+            expect(contains(["2.1"], 1, 11), '[2.1] contains 1.11').to.be.false;
         });
     });
 });

--- a/UTs/PositionFilter.test.js
+++ b/UTs/PositionFilter.test.js
@@ -1,0 +1,29 @@
+const {expect} = require("chai");
+
+const rewire = require('rewire');
+const PositionFilter = rewire('../src/filters/PositionFilter')
+const contains = PositionFilter.__get__("contains");
+
+describe("Position Filter", () => {
+    describe("contains function", ()=>{
+        it("should return true for positions that matched exactly to the example position", () => {
+            expect(contains([1.2, 3, 5], 1, 2), '[1.2, 3, 5] contains 1.2').to.be.true;
+        });
+        it("should return true for all example positions if arr contains only scenario position", () => {
+            expect(contains([1, 3, 5], 1, 2), '[1, 3, 5] contains 1.0').to.be.true;
+        });
+        it("should return false for positions unmatched position with example", () => {
+            expect(contains([1.2, 3, 5], 1, 1), '[1.2, 3, 5] contains 1.1').to.be.false;
+        });
+        it("should handle example position '0' correctly", () => {
+            expect(contains([1.0], 1, 0), '[1.0] contains 1.0"').to.be.true;
+            expect(contains([1.0], 1, 1), '[1.0] contains 1.1').to.be.false;
+        });
+        it("should handle example position more than 9 correctly", () => {
+            expect(contains([1.10], 1, 10), '[1.10] contains 1.10').to.be.true;
+            expect(contains([1.10], 1, 1), '[1.10] contains 1.1').to.be.false;
+            expect(contains([1.11], 1, 11), '[1.11] contains 1.11').to.be.true;
+            expect(contains([2.1], 1, 11), '[2.1] contains 1.11').to.be.false;
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "chai": "^4.3.4",
     "chai-subset": "^1.6.0",
-    "mocha": "^8.4.0"
+    "mocha": "^8.4.0",
+    "rewire": "^6.0.0"
   }
 }

--- a/src/cli/ArgsReader.js
+++ b/src/cli/ArgsReader.js
@@ -43,9 +43,9 @@ function buildConfig(args){
     }else if(arg === "--tags"){
       filterConfig.tags = args[++i];
     }else if(arg === "--only"){
-      filterConfig.include = args[++i].split(",").map( n => +n);
+      filterConfig.include = args[++i].split(",");
     }else if(arg === "--skip"){
-      filterConfig.exclude = args[++i].split(",").map( n => +n);
+      filterConfig.exclude = args[++i].split(",");
     }else if(arg === "--run-config"){ //combination of tags, specs, include, exclude
       config.runConfig = require( args[++i] );
     }else if(arg === "--parallel"){

--- a/src/filters/PositionFilter.js
+++ b/src/filters/PositionFilter.js
@@ -56,13 +56,13 @@
  * * 1.2 presents in [ 1.2, 3, 5 ] => returns true
  * * 1.2 presents in [ 1, 3, 5 ] => returns true
  * * 1.1 presents in [ 1.2, 3, 5 ] => returns false
- * @param {array} arr 
+ * @param {array} arr array of position strings
  * @param {number} s_i scenario index
  * @param {number} e_i example index
  */
  function contains(arr, s_i, e_i){
-    const position = s_i+ (e_i/10);
-    return arr.indexOf(s_i) !== -1 || arr.indexOf(position) !== -1;
+    const position = s_i + "." + e_i;
+    return arr.indexOf(s_i.toString()) !== -1 || arr.indexOf(position) !== -1;
 }
 
 module.exports = filter;


### PR DESCRIPTION
In current implementation, we can't specify first example (0th position) and examples located in two or more digits position as arguements to `--only` or `--skip`.

In the former case, for example, the "first example of the second scenario" is represented as `"1.0"` (since cytorus uses 0-based number for positions), but the `.0` part is dropped when cytorus converts the position from a string to a number at https://github.com/NaturalIntelligence/cytorus/blob/11fd6515789fe1ef066454f9172ac9b236c72a10/src/cli/ArgsReader.js#L46 or https://github.com/NaturalIntelligence/cytorus/blob/11fd6515789fe1ef066454f9172ac9b236c72a10/src/cli/ArgsReader.js#L48.  (`"1.0"` is converted to `1`)

The latter is due to cytorus uses the result of `(scenario position) + (example position) / 10` as the "position".

For example, following two different exmaples have same position of `1.1` and cannot be distinguished:

* the position of the 11th example of the 0th scenario (`0 + 11/10 = 1.1`)
* the position of the 1st example of the 1st scenario (`1 + 1/10 = 1.1`)

I don't know if the position being 0-based is by design or a bug, so in this PR, I only fixed the handling of the position of the the examples.