### PR TITLE
Typo introducing "To Object" datatable transform

### DIFF
--- a/docs/2.WritingTests.md
+++ b/docs/2.WritingTests.md
@@ -53,7 +53,7 @@ Scenario: Make an order from home page
 * `#> story: ...` will help to run tests for a particular user story
 * `#>[]` To transform a datatable into and array for better redability and accessbility in the code. Followings are supported;
     * `#>[]`: To array
-    * `#>[]`: To Object
+    * `#>{}`: To Object
     * `#>[{}]`: To list of objects
 
 


### PR DESCRIPTION
To Object was listed as the same as To Array `#>[]` should be `#>{}`